### PR TITLE
Fix FLT_UID column collision in flights_airspace_profiles_tidy

### DIFF
--- a/R/trajectories.R
+++ b/R/trajectories.R
@@ -77,6 +77,7 @@ airspace_profile_tbl <- function(conn = NULL) {
 #' @return a [dbplyr::tbl_dbi()] with the following columns
 #'
 #' * ID: the so called `SAM ID`, used internally by PRISME
+#' * FLT_UID: flight unique id.
 #' * SEQ_ID: the sequence number of the segment for the relevant airspace profile
 #' * ENTRY_TIME: the time of entry into the relevant airspace
 #' * ENTRY_LON:  the longitude of entry into the relevant airspace
@@ -137,7 +138,7 @@ airspace_profiles_tidy <- function(
 
   flt <- flights_tidy(conn = conn, wef = wef_before, til = til_after)
   ids <- flt |>
-    dplyr::select(.data$ID) |>
+    dplyr::select(.data$ID, .data$FLT_UID) |>
     dplyr::distinct()
 
   prf <- airspace_profile_tbl(conn = conn) |>
@@ -162,9 +163,15 @@ airspace_profiles_tidy <- function(
     )
 
   prf <- prf |>
+    # dplyr::inner_join(flt, sql_on = "LHS.SAM_ID = RHS.ID AND LHS.LOBT = LHS.LOBT") |>
     dplyr::inner_join(ids, by = c("SAM_ID" = "ID")) |>
+    # dply::select(-ID) |>
+    # dplyr::rename(
+    #   ID = .data$SAM_ID
+    # ) |>
     dplyr::select(
       .data$SAM_ID,
+      .data$FLT_UID,
       .data$SEQ_ID,
       .data$ENTRY_TIME,
       .data$ENTRY_LON,

--- a/R/trajectories.R
+++ b/R/trajectories.R
@@ -77,7 +77,6 @@ airspace_profile_tbl <- function(conn = NULL) {
 #' @return a [dbplyr::tbl_dbi()] with the following columns
 #'
 #' * ID: the so called `SAM ID`, used internally by PRISME
-#' * FLT_UID: flight unique id.
 #' * SEQ_ID: the sequence number of the segment for the relevant airspace profile
 #' * ENTRY_TIME: the time of entry into the relevant airspace
 #' * ENTRY_LON:  the longitude of entry into the relevant airspace
@@ -138,7 +137,7 @@ airspace_profiles_tidy <- function(
 
   flt <- flights_tidy(conn = conn, wef = wef_before, til = til_after)
   ids <- flt |>
-    dplyr::select(.data$ID, .data$FLT_UID) |>
+    dplyr::select(.data$ID) |>
     dplyr::distinct()
 
   prf <- airspace_profile_tbl(conn = conn) |>
@@ -163,15 +162,9 @@ airspace_profiles_tidy <- function(
     )
 
   prf <- prf |>
-    # dplyr::inner_join(flt, sql_on = "LHS.SAM_ID = RHS.ID AND LHS.LOBT = LHS.LOBT") |>
     dplyr::inner_join(ids, by = c("SAM_ID" = "ID")) |>
-    # dply::select(-ID) |>
-    # dplyr::rename(
-    #   ID = .data$SAM_ID
-    # ) |>
     dplyr::select(
       .data$SAM_ID,
-      .data$FLT_UID,
       .data$SEQ_ID,
       .data$ENTRY_TIME,
       .data$ENTRY_LON,

--- a/R/trajectories.R
+++ b/R/trajectories.R
@@ -264,10 +264,8 @@ flights_airspace_profiles_tidy <- function(
   cols <- colnames(flt)
 
   flt <- flt |>
-    # dplyr::inner_join(flt, sql_on = "LHS.SAM_ID = RHS.ID AND LHS.LOBT = LHS.LOBT") |>
-    # dplyr::inner_join(prf, by = c("ID" = "ID"))
-    dplyr::inner_join(prf, by = c("ID" = "ID")) |>
-    dplyr::select(cols) |>
+    dplyr::inner_join(ids, by = "ID") |>
+    dplyr::select(dplyr::all_of(cols)) |>
     dplyr::distinct()
 
   flt


### PR DESCRIPTION
airspace_profiles_tidy was selecting FLT_UID from the flight table into its ids subquery, which meant the output contained a FLT_UID column. When flights_airspace_profiles_tidy then joined that result with flights_tidy (which also has FLT_UID), dbplyr disambiguated the duplicate as FLT_UID.x / FLT_UID.y. The downstream select(cols) then failed because the original column name no longer existed.

Fix: only select ID (not FLT_UID) in the ids subquery — FLT_UID was never needed for the join and is not part of the airspace profile output.